### PR TITLE
Fix: Paddle resets to correct position and movement improved

### DIFF
--- a/src/game/GameEngine.ts
+++ b/src/game/GameEngine.ts
@@ -80,7 +80,7 @@ export class GameEngine {
   }
 
   private updatePaddlePosition() {
-    const moveSpeed = 7;
+    const moveSpeed = 10; // Increased from 7
     const currentX = this.paddle.x;
     
     if (this.keyState['ArrowLeft'] || this.keyState['a'] || this.keyState['A']) {
@@ -92,9 +92,9 @@ export class GameEngine {
     
     // 패들이 움직였을 때만 위치 업데이트
     if (this.paddle.targetX !== currentX) {
-      this.lastPaddleX = this.paddle.targetX;
       this.paddle.update();
     }
+    this.lastPaddleX = this.paddle.x; // Always update lastPaddleX to the current paddle position
   }
 
   private initializeLevel() {

--- a/src/game/entities/Paddle.ts
+++ b/src/game/entities/Paddle.ts
@@ -16,7 +16,7 @@ export class Paddle extends Entity {
   update() {
     const diff = this.targetX - this.x;
     if (Math.abs(diff) > 0.1) {
-      this.x += diff * this.speed;
+      this.x += diff * 0.3; // Changed from 0.5
     } else {
       this.x = this.targetX;
     }


### PR DESCRIPTION
- Modified `GameEngine.ts` to ensure `lastPaddleX` always reflects the paddle's current position. This fixes a bug where the paddle would jump to a previous position after a life was lost.
- Increased paddle movement speed in `GameEngine.ts` for better responsiveness.
- Adjusted paddle interpolation in `Paddle.ts` for smoother movement.