### PR TITLE
Fix: 패들이 의도치 않게 원위치로 돌아오는 문제 해결

### DIFF
--- a/src/game/GameEngine.ts
+++ b/src/game/GameEngine.ts
@@ -80,21 +80,26 @@ export class GameEngine {
   }
 
   private updatePaddlePosition() {
-    const moveSpeed = 10; // Increased from 7
+    const moveSpeed = 10;
     const currentX = this.paddle.x;
-    
+    let newTargetX = currentX; // 현재 위치로 초기화
+
     if (this.keyState['ArrowLeft'] || this.keyState['a'] || this.keyState['A']) {
-      this.paddle.targetX = Math.max(0, currentX - moveSpeed);
+      newTargetX = Math.max(0, currentX - moveSpeed);
     }
     if (this.keyState['ArrowRight'] || this.keyState['d'] || this.keyState['D']) {
-      this.paddle.targetX = Math.min(this.canvas.width - this.paddle.width, currentX + moveSpeed);
+      newTargetX = Math.min(this.canvas.width - this.paddle.width, currentX + moveSpeed);
     }
-    
-    // 패들이 움직였을 때만 위치 업데이트
-    if (this.paddle.targetX !== currentX) {
+
+    // targetX가 실제로 변경되었는지 확인
+    if (newTargetX !== currentX) {
+      this.paddle.targetX = newTargetX;
       this.paddle.update();
+      this.lastPaddleX = this.paddle.x; // 패들이 실제로 움직였을 때만 lastPaddleX 업데이트
+    } else {
+      // 키 입력이 없거나 경계에 도달하여 움직이지 않을 때, targetX를 현재 x 위치로 설정하여 불필요한 update() 호출 방지
+      this.paddle.targetX = currentX;
     }
-    this.lastPaddleX = this.paddle.x; // Always update lastPaddleX to the current paddle position
   }
 
   private initializeLevel() {
@@ -199,7 +204,9 @@ export class GameEngine {
         
         if (this.balls.length === 0) {
           this.callbacks.onLifeLost();
-          this.paddle.x = this.lastPaddleX;
+          this.paddle.x = this.canvas.width / 2 - this.paddle.width / 2;
+          this.paddle.targetX = this.paddle.x;
+          this.lastPaddleX = this.paddle.x;
           this.resetBall();
         }
         continue;
@@ -347,7 +354,9 @@ export class GameEngine {
     this.canvas.height = height;
     
     this.paddle.y = height - 30;
-    this.paddle.x = Math.min(this.lastPaddleX, width - this.paddle.width);
+    this.paddle.x = width / 2 - this.paddle.width / 2;
+    this.paddle.targetX = this.paddle.x;
+    this.lastPaddleX = this.paddle.x;
     
     this.blocks = [];
     this.initializeLevel();

--- a/src/game/entities/Paddle.ts
+++ b/src/game/entities/Paddle.ts
@@ -16,7 +16,7 @@ export class Paddle extends Entity {
   update() {
     const diff = this.targetX - this.x;
     if (Math.abs(diff) > 0.1) {
-      this.x += diff * 0.3; // Changed from 0.5
+      this.x += diff * 0.5; // 패들 이동 속도 계수를 0.3에서 0.5로 변경
     } else {
       this.x = this.targetX;
     }


### PR DESCRIPTION
- GameEngine.ts:
  - updatePaddlePosition: `lastPaddleX`가 패들의 실제 이동 시에만 업데이트되도록 수정했습니다. 키 입력이 없거나 패들이 경계에 있을 때 `targetX`를 현재 위치로 명확히 설정하여 의도치 않은 움직임을 방지했습니다.
  - update (공 놓침 시): 패들이 화면 중앙으로 이동하고, `lastPaddleX`도 중앙으로 업데이트되도록 수정했습니다.
  - resize: 창 크기 조절 시 패들이 새로운 캔버스 중앙으로 이동하고, `lastPaddleX`도 중앙으로 업데이트되도록 수정했습니다.

- entities/Paddle.ts:
  - update: 패들 이동 계수를 0.3에서 0.5로 증가시켜 반응성을 향상시켰습니다.

이 변경으로 인해 키 입력이 없을 때 패들이 스스로 움직이거나, 공을 놓친 후 또는 창 크기 조절 후 예기치 않은 위치로 이동하는 문제가 해결되었습니다.