### PR TITLE
Fix: Ensure correct level loads and game screen initializes properly

### DIFF
--- a/src/components/Game.tsx
+++ b/src/components/Game.tsx
@@ -22,6 +22,13 @@ const Game: React.FC<GameProps> = ({ level, onGameOver, onBackToMenu }) => {
     const canvas = canvasRef.current;
     if (!canvas) return;
 
+    const container = canvas.parentElement;
+    if (container) {
+      const rect = container.getBoundingClientRect();
+      canvas.width = rect.width;
+      canvas.height = rect.height;
+    }
+
     // GameEngine 콜백 정의
     const gameCallbacks: GameEngineCallbacks = {
       onScoreChange: (newScore) => setScore(newScore),
@@ -61,7 +68,7 @@ const Game: React.FC<GameProps> = ({ level, onGameOver, onBackToMenu }) => {
     };
 
     // NewGameEngine 인스턴스 생성
-    const gameEngine = new NewGameEngine(canvas, gameCallbacks);
+    const gameEngine = new NewGameEngine(canvas, gameCallbacks, level);
     gameEngineRef.current = gameEngine;
 
     // 초기 생명, 점수, 상태 설정 (엔진에서 설정된 값을 가져옴)
@@ -78,7 +85,6 @@ const Game: React.FC<GameProps> = ({ level, onGameOver, onBackToMenu }) => {
       }
     };
 
-    handleResize(); // 초기 사이즈 설정
     window.addEventListener('resize', handleResize);
 
     // 게임 시작 (엔진의 start는 Playing 상태로 만들고 루프 시작)

--- a/src/game/new_engine/NewGameEngine.ts
+++ b/src/game/new_engine/NewGameEngine.ts
@@ -52,17 +52,18 @@ export class NewGameEngine {
 
   private callbacks: GameEngineCallbacks;
 
-  constructor(canvas: HTMLCanvasElement, callbacks: GameEngineCallbacks) {
+  constructor(canvas: HTMLCanvasElement, callbacks: GameEngineCallbacks, levelNumber: number) {
     this.canvas = canvas;
     this.ctx = canvas.getContext('2d')!;
     this.inputManager = InputManager.getInstance(); // InputManager 싱글톤 인스턴스 사용
     this.callbacks = callbacks;
+    this.currentLevel = levelNumber;
 
     // ballInitialDx, ballInitialDy 설정
     this.ballInitialDx = this.ballSpeed * (Math.random() > 0.5 ? 1 : -1); // 초기 x 방향 랜덤
     this.ballInitialDy = -this.ballSpeed; // 초기 y 방향은 위로
 
-    this.initializeLevel(1); // 레벨 초기화 (패들, 공, 벽돌 생성 포함)
+    this.initializeLevel(this.currentLevel); // 레벨 초기화 (패들, 공, 벽돌 생성 포함)
   }
 
   private initializeLevel(levelNumber: number): void {


### PR DESCRIPTION
The game was previously always defaulting to level 1 and potentially initializing with incorrect canvas dimensions, leading to a blank screen or incorrect level display.

This commit addresses these issues by:

1.  Modifying `NewGameEngine` to accept the desired `levelNumber` in its constructor and use it for level initialization.
2.  Updating `Game.tsx` to:
    - Set the canvas dimensions accurately based on its container *before* the `NewGameEngine` is instantiated.
    - Pass the selected `level` prop to the `NewGameEngine` constructor.

These changes ensure that the selected level is loaded and the game elements are rendered correctly based on the actual screen dimensions at the time of initialization.